### PR TITLE
Add admin command to delete warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,10 @@ Dependencies<br>
 ox_lib<br>
 qb-core<br>
 qb-adminmenu
+
+Commands
+
+```
+/warnings - View your warnings
+/delwarning <warningId> - Delete a warning (admin only)
+```

--- a/server.lua
+++ b/server.lua
@@ -21,3 +21,24 @@ RegisterCommand('warnings', function(source)
         TriggerClientEvent('qb-warnings:client:ShowWarnings', src, results)
     end)
 end)
+
+RegisterCommand('delwarning', function(source, args)
+    local src = source
+    if src == 0 then return end
+
+    -- Basic ace permission check. `command` is granted to admins in server.cfg
+    if not IsPlayerAceAllowed(src, 'command') then
+        TriggerClientEvent('QBCore:Notify', src, 'No permission to run this command.', 'error')
+        return
+    end
+
+    local warnId = tonumber(args[1])
+    if not warnId then
+        TriggerClientEvent('QBCore:Notify', src, 'You must provide a warning ID.', 'error')
+        return
+    end
+
+    exports.oxmysql:execute('DELETE FROM player_warns WHERE warnId = ?', { warnId }, function()
+        TriggerClientEvent('QBCore:Notify', src, 'Warning deleted.', 'success')
+    end)
+end, false)


### PR DESCRIPTION
## Summary
- allow admins to delete warnings with a new `/delwarning <warningId>` command
- document available commands in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6884b2eddea8832899b191a8af686cdc